### PR TITLE
Update for switchy 2.0.0

### DIFF
--- a/src/main/resources/data/rpgstats/switchy_cardinal/stats.json
+++ b/src/main/resources/data/rpgstats/switchy_cardinal/stats.json
@@ -1,6 +1,6 @@
 {
   "default": false,
-  "description": "A module that switches stat levels from SilverAndro's RPGStats",
+  "description": "A module that switches stat levels and XP from SilverAndro's RPGStats",
   "editable": "OPERATOR",
   "components": ["rpgstats:stats", "rpgstats:internal"]
 }

--- a/src/main/resources/data/rpgstats/switchy_cca_modules/stats.json
+++ b/src/main/resources/data/rpgstats/switchy_cca_modules/stats.json
@@ -1,5 +1,5 @@
 {
-  "default": true,
+  "default": false,
   "description": "A module that switches stat levels from SilverAndro's RPGStats",
   "editable": "OPERATOR",
   "components": ["rpgstats:stats", "rpgstats:internal"]

--- a/src/main/resources/data/rpgstats/switchy_cca_modules/stats.json
+++ b/src/main/resources/data/rpgstats/switchy_cca_modules/stats.json
@@ -1,5 +1,6 @@
 {
   "default": true,
-  "importable": "OPERATOR",
+  "description": "A module that switches stat levels from SilverAndro's RPGStats",
+  "editable": "OPERATOR",
   "components": ["rpgstats:stats", "rpgstats:internal"]
 }

--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -48,7 +48,7 @@
       },
       {
         "id": "switchy",
-        "versions": ">=1.8.1",
+        "versions": ">=2.0.0",
         "optional": true
       }
     ]

--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -48,7 +48,7 @@
       },
       {
         "id": "switchy",
-        "versions": ">=2.0.0",
+        "versions": ">=2.0.3",
         "optional": true
       }
     ]


### PR DESCRIPTION
Yeah we broke the data-driven module format in 2.0.0, so here's an update for that.

I've put a big bold warning on the switchy 2.0.0 changelog that booting 2.0 and rpgstats without this update will cause data loss - thankfully on this side a qmj bump handles it no problem.