### PR TITLE
modernise switchy module data

### DIFF
--- a/src/main/resources/assets/rpgstats/lang/en_us.json
+++ b/src/main/resources/assets/rpgstats/lang/en_us.json
@@ -1,4 +1,5 @@
 {
   "key.rpgstats.open_gui": "Open GUI",
-  "category.rpgstats.keybinds": "RPGStats Keybinds"
+  "category.rpgstats.keybinds": "RPGStats Keybinds",
+  "switchy.modules.rpgstats.stats.preview.tooltip": "Mining: %s | Magic: %s | Ranged: %s | Defence: %s | Farming %s | Fishing: %s"
 }

--- a/src/main/resources/assets/rpgstats/switchy_cardinal/stats.json
+++ b/src/main/resources/assets/rpgstats/switchy_cardinal/stats.json
@@ -1,0 +1,14 @@
+{
+	"icon": {
+		"id": "minecraft:iron_sword"
+	},
+	"values": [
+		"rpgstats:stats.rpgstats:mining.level",
+		"rpgstats:stats.rpgstats:magic.level",
+		"rpgstats:stats.rpgstats:ranged.level",
+		"rpgstats:stats.rpgstats:defence.level",
+		"rpgstats:stats.rpgstats:farming.level",
+		"rpgstats:stats.rpgstats:melee.level",
+		"rpgstats:stats.rpgstats:fishing.level"
+	]
+}

--- a/src/main/resources/data/rpgstats/lang/en_us.json
+++ b/src/main/resources/data/rpgstats/lang/en_us.json
@@ -49,5 +49,10 @@
 
   "rpgstats.fakestat.potion_drink_speed": "Potion drink speed",
 
-  "rpgstats.fakestat.bonemeal_efficiency": "Bonemeal efficiency"
+  "rpgstats.fakestat.bonemeal_efficiency": "Bonemeal efficiency",
+
+  "switchy.modules.rpgstats.stats.description": "A module that switches stat levels from SilverAndro's RPGStats.",
+  "switchy.modules.rpgstats.stats.enabled": "You will share stats between all presets.",
+  "switchy.modules.rpgstats.stats.disabled": "You will have separate stat progression between presets.",
+  "switchy.modules.rpgstats.stats.warning": "All other stat levels will be cleared!"
 }

--- a/src/main/resources/data/rpgstats/switchy_cardinal/stats.json
+++ b/src/main/resources/data/rpgstats/switchy_cardinal/stats.json
@@ -1,6 +1,5 @@
 {
   "default": false,
-  "description": "A module that switches stat levels and XP from SilverAndro's RPGStats",
   "editable": "OPERATOR",
   "components": ["rpgstats:stats", "rpgstats:internal"]
 }

--- a/src/main/resources/data/rpgstats/switchy_cca_modules/stats.json
+++ b/src/main/resources/data/rpgstats/switchy_cca_modules/stats.json
@@ -1,5 +1,0 @@
-{
-  "default": true,
-  "importable": "OPERATOR",
-  "components": ["rpgstats:stats", "rpgstats:internal"]
-}

--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -48,15 +48,8 @@
       },
       {
         "id": "switchy",
-        "versions": ">=1.8.1",
+        "versions": ">=2.0.4",
         "optional": true
-      }
-    ],
-    "breaks": [
-      {
-        "id": "switchy",
-        "versions": ">=2.0.0 <2.0.3",
-        "reason": "Switchy bug prevents loading RPGStats compatibility on this version range, resulting in data loss"
       }
     ]
   },


### PR DESCRIPTION
that `breaks` block has prevented any version of switchy from loading since it was introduced (oops).

We swapped to pattern-following translation keys over a literal for descriptions.

Also we have data driven GUI previews now. They're not beautifully crafted but they do the job nicely for json for now.
![image](https://github.com/SilverAndro/RPGStats/assets/55819817/2256181e-53e4-44f9-a4f8-c5a5957eef67)
